### PR TITLE
Fix clock example

### DIFF
--- a/live_component_wrapper.go
+++ b/live_component_wrapper.go
@@ -12,10 +12,12 @@ type LiveComponentWrapper struct {
 	HtmlTemplate       *template.Template
 	LifeTimeChannel    *LifeTimeUpdates
 	Rendered           string
+	component          *LiveComponent
 }
 
 func (l *LiveComponentWrapper) Prepare(lc *LiveComponent) {
 	l.LifeTimeChannel = lc.UpdatesChannel
+	l.component = lc
 }
 
 // TemplateHandler ...
@@ -35,6 +37,6 @@ func (l *LiveComponentWrapper) Mounted(_ *LiveComponent) {
 func (l *LiveComponentWrapper) Commit() {
 	*l.LifeTimeChannel <- ComponentLifeTimeMessage{
 		Stage:     Updated,
-		Component: nil,
+		Component: l.component,
 	}
 }


### PR DESCRIPTION
I can see this is not what you were going for but maybe this can be a temporary fix for server-side driven events to get the clock example in the read me working again. 

Feel free to reject if you have a better solution. 