### PR TITLE
Keydown Watcher. Event and DOM data.

### DIFF
--- a/component.go
+++ b/component.go
@@ -158,17 +158,28 @@ func (l *LiveComponent) SetValueInPath(value string, path string) error {
 }
 
 // InvokeMethodInPath ...
-func (l *LiveComponent) InvokeMethodInPath(path string, valuePath string) error {
-	c := (*l).component
-	v := reflect.ValueOf(c)
-
-	var params []reflect.Value
-
-	if len(valuePath) > 0 {
-		params = append(params, *l.GetFieldFromPath(path))
+func (l *LiveComponent) InvokeMethodInPath(path string, data map[string]string, domEvent *DOMEvent) error {
+	m := reflect.ValueOf(l.component).MethodByName(path)
+	if !m.IsValid() {
+		return fmt.Errorf("not a valid function: %v", path)
 	}
 
-	v.MethodByName(path).Call(params)
+	// TODO: check for errors when calling
+	switch m.Type().NumIn() {
+	case 0:
+		m.Call(nil)
+	case 1:
+		m.Call(
+			[]reflect.Value{reflect.ValueOf(data)},
+		)
+	case 2:
+		m.Call(
+			[]reflect.Value{
+				reflect.ValueOf(data),
+				reflect.ValueOf(domEvent),
+			},
+		)
+	}
 
 	return nil
 }

--- a/html.go
+++ b/html.go
@@ -86,6 +86,10 @@ func SelectorFromNode(e *html.Node) string {
 
 			if attr, ok := attrs["id"]; ok {
 				if len(attr) > 0 {
+					if len(selector) == 0 {
+						return "#" + strings.TrimSpace(attr)
+					}
+
 					elementSelector = elementSelector + "#" + strings.TrimSpace(attr)
 				}
 			}

--- a/html_page.go
+++ b/html_page.go
@@ -9,268 +9,324 @@ var BasePageString = `
 		{{ .Head }}
 	</head>
 	<script type="application/javascript">
-	
-		const findLiveInputsFromElement = (el) => {
-			return el.querySelectorAll('*[go-live-input]')
-		}
-	
-		const findLiveClicksFromElement = (el) => {
-			return el.querySelectorAll('*[go-live-click]')
-		}
-	
 		const goLive = {
 			server: new WebSocket(['ws://', window.location.host, "/ws"].join("")),
-	
+
 			handlers: [],
 			onceHandlers: {},
-	
+
 			getLiveComponent(id) {
-				return document.querySelector(['*[go-live-component-id=', id, ']'].join('') )
+				return document.querySelector(['*[go-live-component-id=', id, ']'].join(''));
 			},
-			getLiveInputs(id) {
-				return findLiveInputsFromElement(this.getLiveContent(id))
-			},
-			getLiveClick(id) {
-				return findLiveClicksFromElement(this.getLiveContent(id))
-			},
+
 			on(name, handler) {
 				const newSize = this.handlers.push({
 					name,
 					handler
-				})
-				return newSize - 1
+				});
+				return newSize - 1;
 			},
-	
+
 			emitOnce(name) {
 				const handler = this.onceHandlers[name]
 				if( !handler ) {
-					this.createOnceHandler(name, true)
-					return
+					this.createOnceHandler(name, true);
+					return;
 				}
 				for( const cb of handler.cbs ){
-					cb()
+					cb();
 				}
 			},
-	
+
 			createOnceHandler(name, called) {
 				this.onceHandlers[name] = {
 					called,
 					cbs: []
-				}
-	
-				return this.onceHandlers[name]
+				};
+
+				return this.onceHandlers[name];
 			},
-	
+
 			once(name, cb) {
-				let handler = this.onceHandlers[name]
-	
+				let handler = this.onceHandlers[name];
+
 				if( !handler ) {
-					handler = this.createOnceHandler(name, false)
+					handler = this.createOnceHandler(name, false);
 				}
-	
-				handler.cbs.push(cb)
+
+				handler.cbs.push(cb);
 			},
-	
+
 			findHandler(name) {
-				return this.handlers.filter( i => i.name === name )
+				return this.handlers.filter( i => i.name === name );
 			},
-	
+
 			emit(name, message) {
 				for (const handler of this.findHandler(name)) {
-					handler.handler(message)
+					handler.handler(message);
 				}
 			},
-	
+
 			off(index) {
-				this.handlers.splice(index, 1)
+				this.handlers.splice(index, 1);
 			},
-	
+
 			connectElement(scopeId, viewElement) {
-	
-				const liveInputs = findLiveInputsFromElement(viewElement)
-				const clickElements = findLiveClicksFromElement(viewElement)
-	
+
+				const clickElements = findLiveClicksFromElement(viewElement);
 				clickElements.forEach(function(element) {
 					if (!element) {
-						return
+						return;
 					}
-	
+
 					element.addEventListener('click', function(_) {
 						goLive.server.send(JSON.stringify({
 							name: "{{ .Enum.EventLiveMethod }}",
 							component_id: scopeId,
 							method_name: element.getAttribute("go-live-click"),
-							value: String(element.value)
-						}))
-					})
-				})
-	
-				liveInputs.forEach(function(element) {
-	
+							method_data: dataFromElementAttributes(element),
+						}));
+					});
+				});
+
+				const keydownElements = findLiveKeyDownFromElement(viewElement);
+				keydownElements.forEach(function(element) {
 					if (!element) {
-						return
+						return;
 					}
-	
-					const type = element.getAttribute("type")
-	
-					element.addEventListener('input', function(_) {
-						let value = element.value
-	
-						if (type === "checkbox") {
-							value = element.checked
+
+					const method = element.getAttribute("go-live-keydown");
+
+					const attrs = element.attributes;
+					let filterKeys = [];
+					for(let i = 0; i < attrs.length; i++) {
+						if (attrs[i].name === "go-live-key" || attrs[i].name.startsWith("go-live-key-")) {
+							filterKeys.push(attrs[i].value);
 						}
-	
+					}
+
+					element.addEventListener('keydown', function(event) {
+						const code = String(event.code);
+						let hit = true;
+
+						if (filterKeys.length !== 0) {
+							hit = false;
+							for (let i = 0; i < filterKeys.length; i++) {
+								if (filterKeys[i] === code) {
+									hit = true;
+
+									break;
+								}
+							}
+						}
+
+						if (hit) {
+							goLive.server.send(JSON.stringify({
+								name: "{{ .Enum.EventLiveMethod }}",
+								component_id: scopeId,
+								method_name: method,
+								method_data: dataFromElementAttributes(element),
+								dom_event: {
+									keyCode: code,
+								},
+							}));
+						}
+					});
+				});
+
+				const liveInputs = findLiveInputsFromElement(viewElement);
+				liveInputs.forEach(function(element) {
+
+					if (!element) {
+						return;
+					}
+
+					const type = element.getAttribute("type");
+
+					element.addEventListener('input', function(_) {
+
+						let value = element.value;
+
+						if (type === "checkbox") {
+							value = element.checked;
+						}
+
 						goLive.server.send(JSON.stringify({
 							name: "{{ .Enum.EventLiveInput }}",
 							component_id: scopeId,
 							key: element.getAttribute("go-live-input"),
 							value: String(value)
-						}))
-					})
-				})
-	
+						}));
+					});
+				});
+
 				goLive.on('{{ .Enum.EventLiveDom }}', (message) => {
-	
+
 					const handleChange = {
 						'{{ .Enum.DiffSetAttr }}': (message) => {
 							const {
 								attr,
 								element
-							} = message
-	
-							const el = viewElement.querySelector(element)
-	
+							} = message;
+
+							const el = viewElement.querySelector(element);
+
 							if( !el ) {
-								console.error("Element not found", element)
-								return
+								console.error("Element not found", element);
+								return;
 							}
-	
+
 							if (attr.Name === "value" && el.value) {
-								el.value = attr.Value
+								el.value = attr.Value;
 							}
-	
+
 							else {
-								el.setAttribute(attr.Name, attr.Value)
+								el.setAttribute(attr.Name, attr.Value);
 							}
-	
+
 						},
 						'{{ .Enum.DiffRemoveAttr }}': (message) => {
 							const {
 								attr,
 								element
-							} = message
-	
-							const el = viewElement.querySelector(element)
-	
+							} = message;
+
+							const el = viewElement.querySelector(element);
+
 							if( !el ) {
-								console.error("Element not found", element)
-								return
+								console.error("Element not found", element);
+								return;
 							}
-	
-							el.removeAttribute(attr.Name)
-	
+
+							el.removeAttribute(attr.Name);
+
 						},
 						'{{ .Enum.DiffReplace }}': (message) => {
 							const {
 								content,
 								element
-							} = message
-	
-							const el = viewElement.querySelector(element)
-	
+							} = message;
+
+							const el = viewElement.querySelector(element);
+
 							if (!el) {
 								console.warn("Element not found with selector", element)
 								return
 							}
-	
+
 							const wrapper = document.createElement('div');
 							wrapper.innerHTML = content;
-	
+
 							el.parentElement.replaceChild(wrapper.firstChild, el)
 						},
 						'{{ .Enum.DiffRemove }}': (message) => {
 							const {
 								element
 							} = message
-	
+
 							const el = viewElement.querySelector(element)
-	
+
 							if (!el) {
 								console.warn("Element not found with selector", element)
 								return
 							}
-	
+
 							el.parentElement.removeChild(el)
 						},
 						'{{ .Enum.DiffSetInnerHtml }}': (message) => {
 							const {
 								content,
 								element
-							} = message
-	
-							const el = viewElement.querySelector(element)
-	
+							} = message;
+
+							const el = viewElement.querySelector(element);
+
 							if (!el) {
-								console.warn("Element not found with selector", element)
-								return
+								console.warn("Element not found with selector", element);
+								return;
 							}
-	
+
 							if (content.trim().length === 0) {
-								return
+								return;
 							}
-	
-							el.innerHTML = content
+
+							el.innerHTML = content;
 
 							// Add listeners to new elements
-							goLive.connectElement(scopeId, el)
+							goLive.connectElement(scopeId, el);
+
 						},
 						'{{ .Enum.DiffAppend }}': (message) => {
 							const {
 								content,
 								element
-							} = message
-	
-							const el = viewElement.querySelector(element)
-	
+							} = message;
+
+							const el = viewElement.querySelector(element);
+
 							if (!el) {
-								console.warn("Element not found with selector", element)
-								return
+								console.warn("Element not found with selector", element);
+								return;
 							}
-	
+
 							const wrapper = document.createElement('div');
 							wrapper.innerHTML = content;
-	
+
 							if (content.trim().length > 0) {
-								el.appendChild(wrapper.firstChild)
+								el.appendChild(wrapper.firstChild);
 							}
-	
-							goLive.connectElement(scopeId, el.lastChild)
+
+							goLive.connectElement(scopeId, el.lastChild);
 						}
 					}
-	
+
 					if (viewElement.getAttribute("go-live-component-id") === message.component_id) {
-						handleChange[message.type.toLowerCase()](message)
+						handleChange[message.type.toLowerCase()](message);
 					}
 				})
 			},
-	
+
 			connect(id) {
-				goLive.connectElement(id, goLive.getLiveComponent(id))
-			},
+				goLive.connectElement(id, goLive.getLiveComponent(id));
+			}
 		}
-	
+
 		goLive.server.onmessage = (rawMessage) => {
-			const message = JSON.parse(rawMessage.data)
-			goLive.emit(message.name, message)
+			const message = JSON.parse(rawMessage.data);
+
+			goLive.emit(message.name, message);
 		}
-	
+
 		goLive.server.onopen = () => {
-			goLive.emitOnce('WS_CONNECTION_OPEN')
+			goLive.emitOnce('WS_CONNECTION_OPEN');
 		}
-	
+
+		const findLiveInputsFromElement = (el) => {
+			return el.querySelectorAll('*[go-live-input]');
+		}
+
+		const findLiveClicksFromElement = (el) => {
+			return el.querySelectorAll('*[go-live-click]');
+		}
+
+		const findLiveKeyDownFromElement = (el) => {
+			return el.querySelectorAll('*[go-live-keydown]');
+		}
+
+		const dataFromElementAttributes = (el) => {
+			const attrs = el.attributes;
+			let data = {};
+			for(let i = 0; i < attrs.length; i++) {
+				if (attrs[i].name.startsWith("go-live-data-")) {
+					data[attrs[i].name.substring(13)] = attrs[i].value
+				}
+			}
+
+			return data
+		}
 	</script>
 	<body>
-		{{ .Body }}
+	{{ .Body }}
 	</body>
 	</html>
 `

--- a/page.go
+++ b/page.go
@@ -126,7 +126,7 @@ func (lp *Page) HandleMessage(m InMessage) error {
 		}
 	case EventLiveMethod:
 		{
-			return c.InvokeMethodInPath(m.MethodName, m.MethodParams)
+			return c.InvokeMethodInPath(m.MethodName, m.MethodData, m.DOMEvent)
 		}
 	case EventLiveDisconnect:
 		{

--- a/session.go
+++ b/session.go
@@ -8,12 +8,17 @@ const (
 )
 
 type InMessage struct {
-	Name         string `json:"name"`
-	ComponentId  string `json:"component_id"`
-	MethodName   string `json:"method_name"`
-	MethodParams string `json:"method_params"`
-	StateKey     string `json:"key"`
-	StateValue   string `json:"value"`
+	Name        string            `json:"name"`
+	ComponentId string            `json:"component_id"`
+	MethodName  string            `json:"method_name"`
+	MethodData  map[string]string `json:"method_data"`
+	StateKey    string            `json:"key"`
+	StateValue  string            `json:"value"`
+	DOMEvent    *DOMEvent         `json:"dom_event"`
+}
+
+type DOMEvent struct {
+	KeyCode string `json:"keyCode"`
 }
 
 type OutMessage struct {


### PR DESCRIPTION
- Call method on keydown (`go-live-keydown`)
  - Limit keydown calls based on attributes `go-live-key` or `go-live-key-*`
- Tidy JavaScript a little
- Pass selected, relevant, DOM event data to server
- Pass method data based on attributes
  - `go-live-data-<key>="<value>"`
  - `go-live-data-foo="bar"` = `map[string]string{"foo": "bar"}`
- Method handlers can take 0, 1, or 2 params
  - 1 = data from attributes, 2 - data and from attributes DOM data

Example usage: https://github.com/SamHennessy/golive-example/commit/8e8f7d5df14c2fd32006bc4c88f3546f22284eca