### PR TITLE
Session Not Found

### DIFF
--- a/component.go
+++ b/component.go
@@ -290,6 +290,10 @@ func (l *LiveComponent) addGoLiveComponentIDAttribute(template string) string {
 
 // Kill ...
 func (l *LiveComponent) Kill() error {
+	if l.component == nil {
+		return errors.New("component nil")
+	}
+
 	l.KillChildren()
 
 	l.log(LogTrace, "WillUnmount", logEx{"name": l.Name})

--- a/html_page.go
+++ b/html_page.go
@@ -292,6 +292,14 @@ var BasePageString = `
 						handleChange[message.type.toLowerCase()](message);
 					}
 				})
+
+                goLive.on('{{ .Enum.EventLiveError }}', (message) => {
+                    console.error(message.type);
+
+                    if (message.type === '{{ index .EnumLiveError ` + "`LiveErrorSessionNotFound`" + `}}') {
+                        window.location.reload(false);
+                    }
+                })
 			},
 
 			connect(id) {

--- a/page.go
+++ b/page.go
@@ -20,6 +20,7 @@ type PageEnum struct {
 	EventLiveInput   string
 	EventLiveMethod  string
 	EventLiveDom     string
+	EventLiveError   string
 	DiffSetAttr      string
 	DiffRemoveAttr   string
 	DiffReplace      string
@@ -47,12 +48,13 @@ type Page struct {
 }
 
 type PageContent struct {
-	Lang   string
-	Body   template.HTML
-	Head   template.HTML
-	Script string
-	Title  string
-	Enum   PageEnum
+	Lang          string
+	Body          template.HTML
+	Head          template.HTML
+	Script        string
+	Title         string
+	Enum          PageEnum
+	EnumLiveError map[string]string
 }
 
 func NewLivePage(c *LiveComponent) *Page {
@@ -90,6 +92,7 @@ func (lp *Page) Render() (string, error) {
 		EventLiveInput:   EventLiveInput,
 		EventLiveMethod:  EventLiveMethod,
 		EventLiveDom:     EventLiveDom,
+		EventLiveError:   EventLiveError,
 		DiffSetAttr:      SetAttr.String(),
 		DiffRemoveAttr:   RemoveAttr.String(),
 		DiffReplace:      Replace.String(),
@@ -97,6 +100,7 @@ func (lp *Page) Render() (string, error) {
 		DiffSetInnerHtml: SetInnerHtml.String(),
 		DiffAppend:       Append.String(),
 	}
+	lp.content.EnumLiveError = LiveErrorMap()
 
 	writer := bytes.NewBufferString("")
 	err := BasePage.Execute(writer, lp.content)

--- a/wire.go
+++ b/wire.go
@@ -15,6 +15,9 @@ func NewWire() *LiveWire {
 func (w *LiveWire) GetSession(s string) *Session {
 	return w.Sessions[s]
 }
+func (w *LiveWire) DeleteSession(s string) {
+	delete(w.Sessions, s)
+}
 
 func (w *LiveWire) CreateSession() (string, *Session, error) {
 	key, _ := GenerateRandomString(48)


### PR DESCRIPTION
If a user browses away from the page and then hits the browser back button, the browser reuses the session cookie, but the connection for that session was closed when they browsed away.

If the session is not found when a WebSocket connection is made, this fix will force the browser to reload the page. The reload will start a new session and give the user a new cookie.

- Delete session on disconnect
- Recover from panics that happen on WebSocket requests
- More error checking
- More logging
- Add ability to send errors to the browser via WebSocket